### PR TITLE
Update metadata for GNOME 40

### DIFF
--- a/emoji-selector@maestroschan.fr/metadata.json
+++ b/emoji-selector@maestroschan.fr/metadata.json
@@ -8,7 +8,8 @@
 		"3.32",
 		"3.34",
 		"3.36",
-		"3.38"
+		"3.38",
+		"40"
 	],
 	"url": "https://github.com/maoschanz/emoji-selector-for-gnome",
 	"uuid": "emoji-selector@maestroschan.fr",


### PR DESCRIPTION
The extension is fully compatible with GNOME 40, it only needs the metadata
file to be updated.